### PR TITLE
fix: remaining codacy nits from PR #11

### DIFF
--- a/src/containers/greeting/Greeting.css
+++ b/src/containers/greeting/Greeting.css
@@ -132,6 +132,7 @@
   .button-greeting-div {
     justify-content: space-around;
   }
+
   .greeting-kicker {
     margin-top: 0;
     text-align: center;

--- a/src/index.css
+++ b/src/index.css
@@ -59,10 +59,7 @@ body {
 }
 body {
   margin: 0;
-  font:
-    19px / 23px Montserrat,
-    "Montserrat",
-    sans-serif;
+  font: 19px / 23px "Montserrat", sans-serif;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
 }

--- a/src/pages/splash/Splash.js
+++ b/src/pages/splash/Splash.js
@@ -159,7 +159,7 @@ class Splash extends Component {
   }
 
   next() {
-    const { count } = this.state;
+    const count = this.state.count;
     const line = BOOT_LINES.at(count);
     if (!line) {
       this.timer = setTimeout(this.finish, 350);


### PR DESCRIPTION
Fixes the 3 issues Codacy still flagged on #11 after the merge: duplicate font-family name in index.css, missing empty line before rule in Greeting.css, and a PMD false positive on object destructuring in Splash.js.

🤖 Generated with [Claude Code](https://claude.com/claude-code)